### PR TITLE
LIBIIIF-119. Updated application to run in Docker in production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,44 @@
-FROM ruby:2.6.3
-WORKDIR /opt/pcdm-manifests
 
-COPY ./Gemfile ./Gemfile.lock /opt/pcdm-manifests/
-RUN bundle install --deployment
-COPY . /opt/pcdm-manifests
+# Dockerfile for the generating pcdm-manifests Rails application Docker image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/pcdm-manifests:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
+
+FROM ruby:2.6.3
+
+# Create a user for the web app.
+RUN addgroup --gid 9999 app && \
+    adduser --uid 9999 --gid 9999 --disabled-password --gecos "Application" app && \
+    usermod -L app
+
+# Configure the main working directory. This is the base
+# directory used in any further RUN, COPY, and ENTRYPOINT
+# commands.
+
+USER app
+WORKDIR /home/app
+
+ENV RAILS_ENV=production
+
+# Copy the Gemfile as well as the Gemfile.lock and install
+# the RubyGems. This is a separate step so the dependencies
+# will be cached unless changes to one of those two files
+# are made.
+COPY --chown=app:app Gemfile Gemfile.lock /home/app/webapp/
+RUN cd /home/app/webapp && \
+    gem install bundler && \
+    bundle install --deployment && \
+    cd ..
+
+# Copy the main application.
+COPY  --chown=app:app . /home/app/webapp/
+
+# Expose port 3000 to the Docker host, so we can access it
+# from the outside.
 EXPOSE 3000
-CMD ["bin/pcdm-manifests.sh"]
+
+WORKDIR /home/app/webapp
+CMD ["/home/app/webapp/bin/pcdm-manifests.sh"]

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,4 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end
+# module ApplicationCable
+#   class Channel < ActionCable::Channel::Base
+#   end
+# end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,4 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end
+# module ApplicationCable
+#   class Connection < ActionCable::Connection::Base
+#   end
+# end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,2 @@
-class ApplicationJob < ActiveJob::Base
-end
+# class ApplicationJob < ActiveJob::Base
+# end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,3 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end
+# class ApplicationRecord < ActiveRecord::Base
+#   self.abstract_class = true
+# end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,5 +68,5 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+#  config.active_record.dump_schema_after_migration = false
 end

--- a/env_example
+++ b/env_example
@@ -1,4 +1,8 @@
-# Enviroment variables for the fcrepo-search webapp
+# Enviroment variables for the pcdm-manifests webapp
+
+# --- config/secrets.yml
+# Secret key used to verify signed cookies
+SECRET_KEY_BASE=
 
 # URL of the solr running in the fcrepo-vagrant
 SOLR_URL=https://solrlocal:8984/solr/fedora4/


### PR DESCRIPTION
Modified application to run in Docker in a manner consistent with other Dockerized applications, including:

* Run the Rails application under an "app" user instead of root
* Set the user id/group id of the "app" user to 9999, to match usage
  in other Dockerized applications.
* Run the application from the /home/app/webapp/ directory, to match
  usage in other Dockerized application.
* Set the RAILS_ENV environment variable to run the application as
  a "production" application
* Commented out additional files not used by the application, and causes errors when run in production mode.
* Added SECRET_KEY_BASE placeholder to env_example.

https://issues.umd.edu/browse/LIBIIIF-119